### PR TITLE
Fix nodejs_helper to use proper key in npm json

### DIFF
--- a/libraries/nodejs_helper.rb
+++ b/libraries/nodejs_helper.rb
@@ -31,9 +31,9 @@ module NodeJs
     end
 
     def npm_package_installed?(package, version = nil, path = nil)
-      list = npm_list(path)['dependencies']
+      list = npm_list(path)
       # Return true if package installed and installed to good version
-      (!list.nil?) && list.key?(package) && (version ? list[package]['version'] == version : true)
+      (!list.nil?) && list['name'] == package && (version ? list['version'] == version : true)
     end
   end
 end


### PR DESCRIPTION
This Fixes #39 

In https://github.com/redguide/nodejs/blob/master/libraries/nodejs_helper.rb#L33-L37 section of the library - it looks like it's using the wrong key to do the proper check for the package being installed. 

For example, when debugging in chef-shell:
```
list = npm_list('/opt/my-app')
chef > pp list
{"name"=>"my-app",
 "version"=>"0.1.15",
 "dependencies"=>
  {"async"=>
    {"version"=>"0.2.10",
     "from"=>"async@~0.2.9",
     "resolved"=>"https://registry.npmjs.org/async/-/async-0.2.10.tgz"},
<ship>

chef > package = 'my-app'
 => "my-app"
chef > list.key?(package)
 => false
chef > list[package]['version']
NoMethodError: undefined method `[]' for nil:NilClass
        from (irb):22
        from /opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.14.6/lib/chef/shell.rb:75:in `block in start'
        from /opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.14.6/lib/chef/shell.rb:74:in `catch'
        from /opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.14.6/lib/chef/shell.rb:74:in `start'
        from /opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.14.6/bin/chef-shell:37:in `<top (required)>'
        from /usr/bin/chef-shell:23:in `load'
        from /usr/bin/chef-shell:23:in `<main>'
```
But if I make the changes like in this PR - this is what i see
```
chef > list = npm_list('/opt/my-app')
chef > list['name']
 => "my-app"
chef > list['version']
 => "0.1.15"
```