### PR TITLE
Fixes name collision with R cookbook

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'guilhem@lettron.fr'
 license 'Apache 2.0'
 description 'Installs/Configures nodejs'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '2.2.1'
+version '2.2.2'
 
 conflicts 'node'
 

--- a/providers/npm.rb
+++ b/providers/npm.rb
@@ -9,7 +9,7 @@ action :install do
     user new_resource.user
     group new_resource.group
     environment 'HOME' => ::Dir.home(new_resource.user), 'USER' => new_resource.user if new_resource.user
-    not_if { package_installed? }
+    not_if { is_npm_package_installed? }
   end
 end
 
@@ -20,11 +20,11 @@ action :uninstall do
     user new_resource.user
     group new_resource.group
     environment 'HOME' => ::Dir.home(new_resource.user), 'USER' => new_resource.user if new_resource.user
-    only_if { package_installed? }
+    only_if { is_npm_package_installed? }
   end
 end
 
-def package_installed?
+def is_npm_package_installed?
   new_resource.package && npm_package_installed?(new_resource.package, new_resource.version, new_resource.path)
 end
 


### PR DESCRIPTION
The R cookbook (https://supermarket.chef.io/cookbooks/r) also uses the name 'package_installed?'. This adds 'npm_' to clarify that we're dealing with npm packages and 'is_' to distinguish from 'npm_package_installed?' defined in https://github.com/redguide/nodejs/blob/master/libraries/nodejs_helper.rb#L33 and called on line 28 .