### PR TITLE
Removed install_not_needed? method from nodejs_helper.rb

### DIFF
--- a/libraries/nodejs_helper.rb
+++ b/libraries/nodejs_helper.rb
@@ -14,12 +14,6 @@ module NodeJs
       end
     end
 
-    def install_not_needed?
-      cmd = Mixlib::ShellOut.new("#{node['nodejs']['node_bin']} --version")
-      version = cmd.run_command.stdout.chomp
-      ::File.exist?("#{node['nodejs']['dir']}/bin/node") && version == "v#{node['nodejs']['version']}"
-    end
-
     def npm_list(path = nil)
       require 'json'
       if path


### PR DESCRIPTION
This method as it isnt called in this cookbook and it references an attribute that no longer exists (node['nodejs']['dir']). It is just confusing to keep it around.