### PR TITLE
Fix to handle Chef 12 metadata attributes in Chef 11

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,9 +4,9 @@ maintainer_email 'guilhem@lettron.fr'
 license 'Apache 2.0'
 description 'Installs/Configures node.js & io.js'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-source_url 'https://github.com/redguide/nodejs'
-issues_url 'https://github.com/redguide/nodejs/issues'
-version '2.4.1'
+source_url 'https://github.com/redguide/nodejs'		if respond_to?(:source_url)
+issues_url 'https://github.com/redguide/nodejs/issues'	if respond_to?(:issues_url)
+version '2.4.2'
 
 conflicts 'node'
 


### PR DESCRIPTION
# CHANGE SUMMARY
source_url and issues_url are Chef 12 attributes that do not have backwards compatibility. This fixes this cookbook so that it can be used previous versions of Chef. AWS OpsWoks for example only supports up to Chef 11, hence why I noticed the issue. 

Here are similar reports of the same issue: 
https://github.com/agileorbit-cookbooks/java/issues/240
https://github.com/jtimberman/mosh-cookbook/pull/18/files
https://github.com/CpuID/users/pull/1/files
https://github.com/opscode-cookbooks/users/pull/93/files