### PR TITLE
Updated deprecated supermarket link

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -1,4 +1,4 @@
-source 'https://supermarket.getchef.com'
+source 'https://supermarket.chef.io/'
 
 metadata
 


### PR DESCRIPTION
Links to 'https://supermarket.chef.io/' instead of 'https://supermarket.getchef.com' as the latter is now deprecated