### PR TITLE
add ABC exception for rubocop to pass

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -26,3 +26,5 @@ TrailingComma:
   Enabled: false
 WordArray:
   Enabled: false
+Metrics/AbcSize:
+  Max: 25


### PR DESCRIPTION
Currently, `rake` fails on the `style` step, because we use too many Assignment Branch Conditions in two places. Since the code is readable, I don't think it should be refactored to appease the default rule.

```shell
$ rake style
Running RuboCop...
Inspecting 25 files
.........CC..............

Offenses:

libraries/nodejs_helper.rb:3:5: C: Assignment Branch Condition size for npm_dist is too high. [23.11/15]
    def npm_dist
    ^^^
providers/npm.rb:40:1: C: Assignment Branch Condition size for npm_package is too high. [24.52/15]
def npm_package
^^^

25 files inspected, 2 offenses detected
RuboCop failed!
```

This PR raises the max ABC size.