### PR TITLE
Fix cookbook with berkshelf api

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Include the nodejs recipe to install node on your system based on the default in
 include_recipe "nodejs"
 ```
 
-### Engine
+### Engine
 
 You can select different engine by setting `node['nodejs']['engine']`
 ```


### PR DESCRIPTION
Remove invalid character. "###��Engine"

This breaks the cookbook when the metadata is transformed to json by berkshelf - see https://github.com/berkshelf/berkshelf-api/issues/112

Broken in 8897278b2b5f892c64bc5e0508ca9530d3af4aa7