### PR TITLE
Don't make homebrew a hard dependency, since it isn't part of the def…

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -14,7 +14,8 @@ depends 'yum-epel'
 depends 'build-essential'
 depends 'ark'
 depends 'apt'
-depends 'homebrew'
+
+suggests 'homebrew'
 
 %w(debian ubuntu centos redhat smartos mac_os_x).each do |os|
   supports os


### PR DESCRIPTION
The homebrew cookbook is not part of the normal distribution in Chef 11. Changing it to a soft dependency allows non-Mac users to include this cookbook without needing to add homebrew to their repository.