### PR TITLE
(rebase) Fix to handle Chef 12 metadata attributes in Chef 11

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,8 +4,8 @@ maintainer_email 'guilhem@lettron.fr'
 license 'Apache 2.0'
 description 'Installs/Configures node.js & io.js'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-source_url 'https://github.com/redguide/nodejs'
-issues_url 'https://github.com/redguide/nodejs/issues'
+source_url 'https://github.com/redguide/nodejs' if respond_to?(:source_url)
+issues_url 'https://github.com/redguide/nodejs/issues' if respond_to?(:issues_url)
 version '2.4.1'
 
 conflicts 'node'


### PR DESCRIPTION
fixes #79 