### PR TITLE
Add support for iojs package through nodesource.

### DIFF
--- a/attributes/packages.rb
+++ b/attributes/packages.rb
@@ -10,5 +10,5 @@ when 'node'
     'default' => ['nodejs']
   )
 when 'iojs'
-  default['nodejs']['packages'] = nil
+  default['nodejs']['packages'] = ['iojs']
 end

--- a/attributes/repo.rb
+++ b/attributes/repo.rb
@@ -10,4 +10,13 @@ when 'node'
   when 'rhel'
     default['nodejs']['install_repo'] = true
   end
+when 'iojs'
+  case node['platform_family']
+  when 'debian'
+    default['nodejs']['install_repo'] = true
+
+    default['nodejs']['repo']      = 'https://deb.nodesource.com/iojs_2.x'
+    default['nodejs']['keyserver'] = 'keyserver.ubuntu.com'
+    default['nodejs']['key']       = '1655a0ab68576280'
+  end
 end


### PR DESCRIPTION
There are two package repositories on nodesource for iojs - 1.x and 2.x. This adds support for the 2.x repository.