### PR TITLE
Symlink node/npm/iojs into /usr/local/bin.

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -40,3 +40,7 @@ default['nodejs']['binary']['checksum']['linux_x86'] = '8fa2d952556c8b5aa37c077e
 default['nodejs']['binary']['checksum']['linux_arm-pi'] = '52a0f6ed9c0be1ea5f79de6527c481c1b803edbea6413a4fdc65a45ad401565d'
 
 default['nodejs']['make_threads'] = node['cpu'] ? node['cpu']['total'].to_i : 2
+
+# Other cookbooks like, opsworks_nodejs, symlink to /usr/local/bin.
+# We create similar symlinks to maintain compatibility.
+default['nodejs']['make_symlink'] = true

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -19,3 +19,17 @@
 #
 
 include_recipe "nodejs::nodejs_from_#{node['nodejs']['install_method']}"
+
+if node['nodejs']['make_symlink']
+  link '/usr/local/bin/node' do
+    to '/usr/bin/node'
+  end
+
+  link '/usr/local/bin/npm' do
+    to '/usr/bin/npm'
+  end
+
+  link '/usr/local/bin/iojs' do
+    to '/usr/bin/iojs'
+  end
+end


### PR DESCRIPTION
Other nodejs cookbooks (most notably the opsworks_nodejs cookbook) installs node into /usr/local/bin. This maintains compatibility to make the switch easier.