### PR TITLE
Remove apt-transport-https package declaration

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -13,7 +13,7 @@ conflicts 'node'
 depends 'yum-epel'
 depends 'build-essential'
 depends 'ark'
-depends 'apt'
+depends 'apt', '>= 2.9.1'
 depends 'homebrew'
 
 %w(debian ubuntu centos redhat smartos mac_os_x).each do |os|

--- a/recipes/repo.rb
+++ b/recipes/repo.rb
@@ -2,8 +2,6 @@ case node['platform_family']
 when 'debian'
   include_recipe 'apt'
 
-  package 'apt-transport-https'
-
   apt_repository 'node.js' do
     uri node['nodejs']['repo']
     distribution node['lsb']['codename']


### PR DESCRIPTION
This package is installed in recent versions of apt::default. As a result,
this package is declared twice resulting in CHEF-3694.