### PR TITLE
Changed the apt version to always be 3.0

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -3,6 +3,6 @@ source 'https://supermarket.chef.io/'
 metadata
 
 group :integration do
-  cookbook 'apt'
+  cookbook 'apt', '= 3.0.0'
   cookbook 'nodejs_test', :path => './test/cookbooks/nodejs_test'
 end

--- a/metadata.rb
+++ b/metadata.rb
@@ -13,7 +13,7 @@ conflicts 'node'
 depends 'yum-epel'
 depends 'build-essential'
 depends 'ark'
-depends 'apt', '>= 2.9.1'
+depends 'apt', '~> 3.0.0'
 depends 'homebrew'
 
 %w(debian ubuntu centos redhat smartos mac_os_x).each do |os|


### PR DESCRIPTION
My AWS OpsWorks Chef 11 deployment started failing this week out of no where. The stacktrace was...

```
[2016-06-08T00:44:27+00:00] ERROR: Running exception handlers
[2016-06-08T00:44:27+00:00] ERROR: Exception handlers complete
[2016-06-08T00:44:27+00:00] FATAL: Stacktrace dumped to /var/lib/aws/opsworks/cache.stage2/chef-stacktrace.out
[2016-06-08T00:44:27+00:00] ERROR: This resource is written with Chef 12.5 custom resources, and requires at least Chef 12.0 used with the compat_resource cookbook, it will not work with Chef 11.x clients, and those users must pin their cookbooks to older versions or upgrade.
[2016-06-08T00:44:27+00:00] FATAL: Chef::Exceptions::ChildConvergeError: Chef run process exited unsuccessfully (exit code 1)
```

Apparently we're now trying to download a `compat_resource` cookbook, which is only compatible with Chef 12. After some research, it looks like the [apt cookbook](https://github.com/chef-cookbooks/apt/commit/d4bf018390b3da150c0d3bb5def7d96218b5979c), which is dependent on the `compat_resource` cookbook, released a 4.0.0 update on June 2nd and it now only supports Chef 12.

I'm not sure if this cookbook is meant to support both Chef 11 and 12, but these changes fix compatibility for Chef 11. I didn't test Chef 12. :)