### PR TITLE
Define ChefSpec matcher for do_nothing & notifies

### DIFF
--- a/libraries/matchers.rb
+++ b/libraries/matchers.rb
@@ -1,4 +1,6 @@
 if defined?(ChefSpec)
+  ChefSpec.define_matcher :nodejs_npm
+
   def install_nodejs_npm(resource_name)
     ChefSpec::Matchers::ResourceMatcher.new(:nodejs_npm, :install, resource_name)
   end


### PR DESCRIPTION
Allows the do_nothing and notifies mechanisms in ChefSpec to work.