### PR TITLE
Package based install to support latest version of NodeJS intead of the legacy systems

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -18,11 +18,18 @@
 #
 
 case node['platform_family']
-when 'smartos', 'rhel', 'debian', 'fedora', 'mac_os_x'
+when 'smartos', 'debian', 'fedora', 'mac_os_x'
   default['nodejs']['install_method'] = 'package'
-else
-  default['nodejs']['install_method'] = 'source'
+when 'rhel'
+        if node['platform'] == 'amazon'
+            default['nodejs']['install_method'] = 'package'
+        elsif node['platform'] == 'centos'
+            default['nodejs']['install_method'] = 'package'
+        else 
+			default['nodejs']['install_method'] = 'source'				
+        end
 end
+
 
 default['nodejs']['engine'] = 'node' # or iojs
 

--- a/attributes/packages.rb
+++ b/attributes/packages.rb
@@ -5,7 +5,8 @@ case node['nodejs']['engine']
 when 'node'
   default['nodejs']['packages'] = value_for_platform_family(
     'debian' => node['nodejs']['install_repo'] ? ['nodejs'] : ['nodejs', 'npm', 'nodejs-dev'],
-    %w(rhel fedora) => ['nodejs', 'nodejs-devel', 'npm'],
+    #%w(rhel fedora) => ['nodejs', 'nodejs-devel', 'npm'],
+    %w(rhel fedora) => ['nodejs', 'nodejs-devel'],  ## seems npm gets installed when we install nodejs nodejs-devel
     'mac_os_x' => ['node'],
     'freebsd' => %w(node npm),
     'default' => ['nodejs']

--- a/attributes/repo.rb
+++ b/attributes/repo.rb
@@ -9,6 +9,11 @@ when 'node'
     default['nodejs']['key']       = '1655a0ab68576280'
   when 'rhel'
     default['nodejs']['install_repo'] = true
+	### Custom repo for 4.6.x nodejs # swapnil #
+    #default['nodejs']['repo']      = '=https://rpm.nodesource.com/pub_4.x/el/7/$basearch'
+    #default['nodejs']['keyserver'] = 'rpm.nodesource.com/pub/el/'
+    ##default['nodejs']['key']       = 'NODESOURCE-GPG-SIGNING-KEY-EL'
+    #default['nodejs']['key']       = '0x34FA74DD'
   end
 when 'iojs'
   case node['platform_family']

--- a/metadata.json
+++ b/metadata.json
@@ -1,0 +1,65 @@
+{
+  "name": "nodejs",
+  "description": "Installs/Configures node.js & io.js",
+  "long_description": "# [nodejs-cookbook](https://github.com/redguide/nodejs)\n\n[![CK Version](http://img.shields.io/cookbook/v/nodejs.svg?branch=master)](https://supermarket.getchef.com/cookbooks/nodejs) [![Build Status](https://img.shields.io/travis/redguide/nodejs.svg)](https://travis-ci.org/redguide/nodejs) [![Gitter chat](https://badges.gitter.im/redguide/nodejs.svg)](https://gitter.im/redguide/nodejs)\n\nInstalls node.js/io.js and manages npm\n\n## Requirements\n\n### Platforms\n\n- Debian/Ubuntu\n- RHEL/CentOS/Scientific/Amazon/Oracle\n\nNote: Source installs require GCC 4.8+, which is not included on older distro releases\n\n### Chef\n\n- Chef 11+\n\n### Cookbooks\n\n- yum-epel\n- build-essential\n- ark\n- apt\n- homebrew\n\n## Usage\n\nInclude the nodejs recipe to install node on your system based on the default installation method:\n\n```chef\ninclude_recipe \"nodejs\"\n```\n\n### Engine\n\nYou can select different engine by setting `node['nodejs']['engine']`\n\n```\nnode['nodejs']['engine'] => 'node' # default\nnode['nodejs']['engine'] => 'iojs'\n```\n\nYou can also use recipes `nodejs::nodejs` or `nodejs::iojs`.\n\n### Install methods\n\n#### Package\n\nInstall node from packages:\n\n```chef\nnode['nodejs']['install_method'] = 'package' # Not necessary because it's the default\ninclude_recipe \"nodejs\"\n# Or\ninclude_recipe \"nodejs::nodejs_from_package\"\n```\n\nNote that only apt (Ubuntu, Debian) appears to have up to date packages available. Centos, RHEL, etc are non-functional (try `nodejs_from_binary` for those).\n\n#### Binary\n\nInstall node from official prebuilt binaries:\n\n```chef\nnode['nodejs']['install_method'] = 'binary'\ninclude_recipe \"nodejs\"\n# Or\ninclude_recipe \"nodejs::nodejs_from_binary\"\n# Or set a specific version of nodejs to be installed\nnode.default['nodejs']['install_method'] = 'binary'\nnode.default['nodejs']['version'] = '5.9.0'\nnode.default['nodejs']['binary']['checksum'] = '99c4136cf61761fac5ac57f80544140a3793b63e00a65d4a0e528c9db328bf40'\n```\n\n#### Source\n\nInstall node from sources:\n\n```chef\nnode['nodejs']['install_method'] = 'source'\ninclude_recipe \"nodejs\"\n# Or\ninclude_recipe \"nodejs::nodejs_from_source\"\n```\n\n## NPM\n\nNpm is included in nodejs installs by default. By default, we are using it and call it `embedded`. Adding recipe `nodejs::npm` assure you to have npm installed and let you choose install method with `node['nodejs']['npm']['install_method']`\n\n```chef\ninclude_recipe \"nodejs::npm\"\n```\n\n_Warning:_ This recipe will include the `nodejs` recipe, which by default includes `nodejs::nodejs_from_package` if you did not set `node['nodejs']['install_method']`.\n\n## Custom Resources (Providers)\n\n### nodejs_npm\n\n`nodejs_npm` let you install npm packages from various sources:\n\n- npm registry:\n\n  - name: `attribute :package`\n  - version: `attribute :version` (optional)\n\n- url: `attribute :url`\n\n  - for git use `git://{your_repo}`\n\n- from a json (package.json by default): `attribute :json`\n\n  - use `true` for default\n  - use a `String` to specify json file\n\nPackages can be installed globally (by default) or in a directory (by using `attribute :path`)\n\nYou can specify an `NPM_TOKEN` environment variable for accessing [NPM private modules](https://docs.npmjs.com/private-modules/intro) by using `attribute :npm_token`\n\nYou can append more specific options to npm command with `attribute :options` array :\n\n- use an array of options (w/ dash), they will be added to npm call.\n- ex: `['--production','--force']` or `['--force-latest']`\n\nThis LWRP attempts to use vanilla npm as much as possible (no custom wrapper).\n\n### Packages\n\n```ruby\nnodejs_npm \"express\"\n\nnodejs_npm \"async\" do\n  version \"0.6.2\"\nend\n\nnodejs_npm \"request\" do\n  url \"github mikeal/request\"\nend\n\nnodejs_npm \"grunt\" do\n  path \"/home/random/grunt\"\n  json true\n  user \"random\"\nend\n\nnodejs_npm \"my_private_module\" do\n  path \"/home/random/myproject\" # The root path to your project, containing a package.json file\n  json true\n  npm_token \"12345-abcde-e5d4c3b2a1\"\n  user \"random\"\n  options ['--production'] # Only install dependencies. Skip devDependencies\nend\n```\n\n[Working Examples](test/cookbooks/nodejs_test/recipes/npm.rb)\n\nOr add packages via attributes (which accept the same attributes as the LWRP above):\n\n```json\n\"nodejs\": {\n  \"npm_packages\": [\n    {\n      \"name\": \"express\"\n    },\n    {\n      \"name\": \"async\",\n      \"version\": \"0.6.2\"\n    },\n    {\n      \"name\": \"request\",\n      \"url\": \"github mikeal/request\"\n    }\n    {\n      \"name\": \"grunt\",\n      \"path\": \"/home/random/grunt\",\n      \"json\": true,\n      \"user\": \"random\"\n    }\n  ]\n}\n```\n\n## License & Authors\n\n**Author:** Marius Ducea (marius@promethost.com) **Author:** Nathan L Smith (nlloyds@gmail.com) **Author:** Guilhem Lettron (guilhem@lettron.fr) **Author:** Barthelemy Vessemont (bvessemont@gmail.com)\n\n**Copyright:** 2008-2016, Chef Software, Inc.\n\n```\nLicensed under the Apache License, Version 2.0 (the \"License\");\nyou may not use this file except in compliance with the License.\nYou may obtain a copy of the License at\n\n    http://www.apache.org/licenses/LICENSE-2.0\n\nUnless required by applicable law or agreed to in writing, software\ndistributed under the License is distributed on an \"AS IS\" BASIS,\nWITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\nSee the License for the specific language governing permissions and\nlimitations under the License.\n```\n",
+  "maintainer": "redguide",
+  "maintainer_email": "guilhem@lettron.fr",
+  "license": "Apache 2.0",
+  "platforms": {
+    "debian": ">= 0.0.0",
+    "ubuntu": ">= 0.0.0",
+    "centos": ">= 0.0.0",
+    "redhat": ">= 0.0.0",
+    "scientific": ">= 0.0.0",
+    "oracle": ">= 0.0.0",
+    "amazon": ">= 0.0.0",
+    "smartos": ">= 0.0.0",
+    "mac_os_x": ">= 0.0.0"
+  },
+  "dependencies": {
+    "yum-epel": ">= 0.0.0",
+    "build-essential": ">= 0.0.0",
+    "ark": ">= 0.0.0",
+    "apt": ">= 2.9.1",
+    "homebrew": ">= 0.0.0"
+  },
+  "recommendations": {
+
+  },
+  "suggestions": {
+
+  },
+  "conflicting": {
+
+  },
+  "providing": {
+
+  },
+  "replacing": {
+
+  },
+  "attributes": {
+
+  },
+  "groupings": {
+
+  },
+  "recipes": {
+
+  },
+  "version": "3.0.0",
+  "source_url": "https://github.com/redguide/nodejs",
+  "issues_url": "https://github.com/redguide/nodejs/issues",
+  "privacy": false,
+  "chef_versions": [
+    [
+      ">= 11.0"
+    ]
+  ],
+  "ohai_versions": [
+
+  ],
+  "gems": [
+
+  ]
+}

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -18,6 +18,6 @@
 # limitations under the License.
 #
 
-include_recipe 'nodejs::install'
+#include_recipe 'nodejs::install'
 include_recipe 'nodejs::npm'
 include_recipe 'nodejs::npm_packages'

--- a/recipes/repo.rb
+++ b/recipes/repo.rb
@@ -1,14 +1,28 @@
 case node['platform_family']
 when 'debian'
-  include_recipe 'apt'
-
-  apt_repository 'node.js' do
-    uri node['nodejs']['repo']
-    distribution node['lsb']['codename']
-    components ['main']
-    keyserver node['nodejs']['keyserver']
-    key node['nodejs']['key']
-  end
+apt_package 'curl'
+		execute 'nodejs_ppa_install' do
+		command 'curl -sL https://deb.nodesource.com/setup_6.x | sudo -E bash -'
+		end
+#  include_recipe 'apt'
+#
+#  apt_repository 'node.js' do
+#    uri node['nodejs']['repo']
+#    distribution node['lsb']['codename']
+#    components ['main']
+#    keyserver node['nodejs']['keyserver']
+#    key node['nodejs']['key']
+#  end
 when 'rhel'
-  include_recipe 'yum-epel'
+  #include_recipe 'yum-epel'
+	yum_package 'curl'
+	execute 'nodejs_ppa_install' do
+	command 'curl -sL https://rpm.nodesource.com/setup_6.x | sudo -E bash -'
+end
+
+
+#apt_repository 'nginx-php' do
+#  uri          'ppa:nginx/stable'
+#  distribution node['lsb']['codename']
+
 end

--- a/recipes/repo.rb
+++ b/recipes/repo.rb
@@ -16,8 +16,8 @@ apt_package 'curl'
 when 'rhel'
   #include_recipe 'yum-epel'
 	yum_package 'curl'
-	execute 'nodejs_ppa_install' do
-	command 'curl -sL https://rpm.nodesource.com/setup_6.x | sudo -E bash -'
+	execute 'nodejs_repo_install' do
+	command 'curl -sL https://rpm.nodesource.com/setup_6.x | bash - '
 end
 
 


### PR DESCRIPTION
Updated code so that package based installation fetches the latest stable NodeJs version instead of default legacy packages. This will be useful since the source based install is very slow for flavors I tested : namely Centos7, Ubuntu 12.04, 14.04.

The changes includes some hacks to fetch the latest PPA repo for ubuntu & nodesource repo for Rhel based systems.

I have tested the cookbook changes in Amazon Linux(latest) , Ubuntu  12.04, 14.04. 16.04, Centos 7.

