### PR TITLE
Install npm from repo.

### DIFF
--- a/attributes/packages.rb
+++ b/attributes/packages.rb
@@ -4,7 +4,7 @@ include_attribute 'nodejs::repo'
 case node['nodejs']['engine']
 when 'node'
   default['nodejs']['packages'] = value_for_platform_family(
-    'debian' => node['nodejs']['install_repo'] ? ['nodejs'] : ['nodejs', 'npm', 'nodejs-dev'],
+    'debian' => ['nodejs', 'npm', 'nodejs-dev'],
     %w(rhel fedora) => ['nodejs', 'nodejs-devel', 'npm'],
     'mac_os_x' => ['node'],
     'freebsd' => %w(node npm),


### PR DESCRIPTION
Always install `npm` and `nodejs-dev`. 
This fixes an issue wherein `npm` was not being installed on `ubuntu16.04`.