### PR TITLE
A more sensible approach to detecting machine architecture?

### DIFF
--- a/recipes/nodejs_from_binary.rb
+++ b/recipes/nodejs_from_binary.rb
@@ -23,9 +23,18 @@ node.force_override['nodejs']['install_method'] = 'binary' # ~FC019
 # Shamelessly borrowed from http://docs.chef.io/dsl_recipe_method_platform.html
 # Surely there's a more canonical way to get arch?
 arch = if node['kernel']['machine'] =~ /armv6l/
+         # FIXME: This should really check the version of node we're looking for
+         # as it seems that they haven't build an `arm-pi` version in a while...
+         # if it's old, return this, otherwise just return `node['kernel']['machine']`
          'arm-pi' # assume a raspberry pi
+       elsif node['kernel']['machine'] =~ /aarch64/
+         'arm64'
+       elsif node['kernel']['machine'] =~ /x86_64/
+         'x64'
+       elsif node['kernel']['machine'] =~ /\d86/
+         'x86'
        else
-         node['kernel']['machine'] =~ /x86_64/ ? 'x64' : 'x86'
+         node['kernel']['machine']
        end
 
 # package_stub is for example: "node-v6.9.1-linux-x64.tar.xz"


### PR DESCRIPTION
Preserving that `arm-pi` branch as there might actually be people still relying on the 0.10.x builds of node elsewhere, though I'd much rather let that fall through to the else case because `armv6l` is actually still supported.