### PR TITLE
the URL is a string under the key "resolved"

### DIFF
--- a/libraries/nodejs_helper.rb
+++ b/libraries/nodejs_helper.rb
@@ -26,7 +26,7 @@ module NodeJs
     end
 
     def url_valid?(list, package)
-      list.fetch(package, {}).fetch('resolved', '').include?('url')
+      list.fetch(package, {}).include?('resolved')
     end
 
     def version_valid?(list, package, version)


### PR DESCRIPTION
The output of `npm list --global --json` which is used by the npm_list method in libraries/nodejs_helper.rb returns JSON that is of different form than the current implementation expects. I am guessing a previous version of npm would return a hash value instead of a string for the `resolved` key but it is now a string. This PR checks for the existence of the `resolved` key instead of the existence of `resolved[url]`.

```
# npm list --global --json
{
  "dependencies": {
    "forever": {
      "version": "0.15.3",
      "from": "forever@latest",
      "resolved": "https://registry.npmjs.org/forever/-/forever-0.15.3.tgz",
      "dependencies": {
        "cliff": {
          "version": "0.1.10",
          "from": "cliff@>=0.1.9 <0.2.0",
          "resolved": "https://registry.npmjs.org/cliff/-/cliff-0.1.10.tgz",
          "dependencies": {
            "colors": {
              "version": "1.0.3",
              "from": "colors@>=1.0.3 <1.1.0",
              "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz"
            },
            "eyes": {
              "version": "0.1.8",
              "from": "eyes@>=0.1.8 <0.2.0",
              "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz"
            }
          }
        },
```