### PR TITLE
Add nodejs management toggler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # NodeJS Cookbook Changelog
 
+## 3.0.1 (2017-03-23)
+
+- Added node['nodejs']['manage_node'] attribute to use only cookbook's LWRP (required to manage node by nvm)
+
 ## 3.0.0 (2016-11-02)
 
 - Updated the default release to the nodejs 6.9.1\. This requires C++11 extensions to compile, which are only present in GCC 4.8+. Due to this RHEL 5/6 and Ubuntu 12.04 are not supported if using this version.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -40,3 +40,5 @@ default['nodejs']['binary']['checksum']['linux_x86'] = 'f9b2ca03016e45bc35d2441a
 default['nodejs']['binary']['checksum']['linux_arm64'] = '7aa69b6c8cff578d0d97d5bd4f76941b2fade5476f0408d53828666ee427dd4e'
 
 default['nodejs']['make_threads'] = node['cpu'] ? node['cpu']['total'].to_i : 2
+
+default['nodejs']['manage_node'] = true

--- a/metadata.rb
+++ b/metadata.rb
@@ -7,7 +7,7 @@ long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 source_url 'https://github.com/redguide/nodejs' if respond_to?(:source_url)
 issues_url 'https://github.com/redguide/nodejs/issues' if respond_to?(:issues_url)
 chef_version '>= 11.0' if respond_to?(:chef_version)
-version '3.0.0'
+version '3.0.1'
 
 depends 'yum-epel'
 depends 'build-essential'

--- a/providers/npm.rb
+++ b/providers/npm.rb
@@ -60,5 +60,5 @@ end
 
 def initialize(*args)
   super
-  @run_context.include_recipe 'nodejs::npm'
+  @run_context.include_recipe 'nodejs::npm' if node['nodejs']['manage_node']
 end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -18,6 +18,6 @@
 # limitations under the License.
 #
 
-include_recipe 'nodejs::install'
-include_recipe 'nodejs::npm'
-include_recipe 'nodejs::npm_packages'
+include_recipe 'nodejs::install' if node['nodejs']['manage_node']
+include_recipe 'nodejs::npm' if node['nodejs']['manage_node']
+include_recipe 'nodejs::npm_packages' if node['nodejs']['manage_node']


### PR DESCRIPTION
Required for manage nodejs with external tools, like NVM and use only LWRP to manage npm packages etc