### PR TITLE
Add binary install example with user-provided url

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,12 +66,19 @@ Install node from official prebuilt binaries:
 ```chef
 node['nodejs']['install_method'] = 'binary'
 include_recipe "nodejs"
+
 # Or
 include_recipe "nodejs::nodejs_from_binary"
+
 # Or set a specific version of nodejs to be installed
 node.default['nodejs']['install_method'] = 'binary'
 node.default['nodejs']['version'] = '5.9.0'
 node.default['nodejs']['binary']['checksum'] = '99c4136cf61761fac5ac57f80544140a3793b63e00a65d4a0e528c9db328bf40'
+
+# Or fetch the binary from your own location
+node.default['nodejs']['install_method'] = 'binary'
+node.default['nodejs']['binary']['url'] = 'https://s3.amazonaws.com/my-bucket/node-v7.8.0-linux-x64.tar.gz'
+node.default['nodejs']['binary']['checksum'] = '0bd86f2a39221b532172c7d1acb57f0b0cba88c7b82ea74ba9d1208b9f6f9697'
 ```
 
 #### Source


### PR DESCRIPTION
Just adds an example of a binary install using a user-provided url to the readme. Took me a bit of digging to work out how to do this w/o an example.
