### PR TITLE
Change Amazon Linux to install NodeJS from nodesource repositories rather than epel

### DIFF
--- a/attributes/packages.rb
+++ b/attributes/packages.rb
@@ -3,13 +3,18 @@ include_attribute 'nodejs::repo'
 
 case node['nodejs']['engine']
 when 'node'
-  default['nodejs']['packages'] = value_for_platform_family(
-    'debian' => node['nodejs']['install_repo'] ? ['nodejs'] : ['nodejs', 'npm', 'nodejs-dev'],
-    %w(rhel fedora) => ['nodejs', 'nodejs-devel', 'npm'],
-    'mac_os_x' => ['node'],
-    'freebsd' => %w(node npm),
-    'default' => ['nodejs']
-  )
+  if platform? 'amazon'
+    default['nodejs']['packages'] = ['nodejs', 'nodejs-devel']
+  else
+    default['nodejs']['packages'] = value_for_platform_family(
+      'debian' => node['nodejs']['install_repo'] ? ['nodejs'] : ['nodejs', 'npm', 'nodejs-dev'],
+      %w(rhel fedora) => ['nodejs', 'nodejs-devel', 'npm'],
+      'mac_os_x' => ['node'],
+      'freebsd' => %w(node npm),
+      'default' => ['nodejs']
+    )
+  end
+
 when 'iojs'
   default['nodejs']['packages'] = ['iojs']
 end

--- a/recipes/repo.rb
+++ b/recipes/repo.rb
@@ -10,5 +10,16 @@ when 'debian'
     key node['nodejs']['key']
   end
 when 'rhel'
-  include_recipe 'yum-epel'
+  if platform? 'amazon'
+    script_name = "setup_#{node['nodejs']['version'].to_i}.x"
+
+    remote_file "#{Chef::Config['file_cache_path']}/#{script_name}" do
+      source "https://rpm.nodesource.com/#{script_name}"
+      mode '0755'
+    end
+
+    execute "#{Chef::Config['file_cache_path']}/#{script_name}"
+  else
+    include_recipe 'yum-epel'
+  end
 end


### PR DESCRIPTION
### Description

This pull request allows a newer version than 0.1.x of NodeJS to be installed on Amazon Linux.  Currently cookbook only installs from epel which is massively out of date.

### Issues Resolved

#167 

### Check List

- [ ] All tests pass.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
