### PR TITLE
fix url_valid? for checking installed npm packages

### DIFF
--- a/libraries/nodejs_helper.rb
+++ b/libraries/nodejs_helper.rb
@@ -26,7 +26,7 @@ module NodeJs
     end
 
     def url_valid?(list, package)
-      list.fetch(package, {}).fetch('resolved', '').include?('url')
+      !list.fetch(package, {}).fetch('resolved', '').empty?
     end
 
     def version_valid?(list, package, version)


### PR DESCRIPTION
### Description

Fixes `not_if` guard on npm packages by correctly checking installed npm packages.

### Issues Resolved

Without this fix, npm packages will attempt to be installed on every Chef run, because the `npm list` check doesn't match against the `resolved` urls correctly (it is looking for the `'url'` string, while the resolved string can actually contain any valid URLs without the exact string 'url' in them.)

I was able to manually reproduce the issue with multiple `converge` runs against the existing test-kitchen integration cookbook, on the `package-ubuntu-1404` platform.

### Check List

- [ ] All tests pass.
- [ ] New functionality includes testing. (could use help on this)
- [ ] New functionality has been documented in the README if applicable
