### PR TITLE
Fix for hardcoded Repo URL's

### DIFF
--- a/attributes/repo.rb
+++ b/attributes/repo.rb
@@ -1,12 +1,16 @@
+# Grab Node.JS Major Version
+node_major = node['nodejs']['version'].to_i
+
 case node['platform_family']
 when 'debian'
   default['nodejs']['install_repo'] = true
-  default['nodejs']['repo']         = 'https://deb.nodesource.com/node_6.x'
+  default['nodejs']['repo']         = "https://deb.nodesource.com/node_#{node_major}.x"
   default['nodejs']['keyserver']    = 'keyserver.ubuntu.com'
   default['nodejs']['key']          = '1655a0ab68576280'
 when 'rhel', 'amazon'
   default['nodejs']['install_repo'] = true
   release_ver = platform?('amazon') ? 6 : node['platform_version'].to_i
-  default['nodejs']['repo']         = "https://rpm.nodesource.com/pub_6.x/el/#{release_ver}/$basearch"
+
+  default['nodejs']['repo']         = "https://rpm.nodesource.com/pub_#{node_major}.x/el/#{release_ver}/$basearch"
   default['nodejs']['key']          = 'https://rpm.nodesource.com/pub/el/NODESOURCE-GPG-SIGNING-KEY-EL'
 end


### PR DESCRIPTION
Allow attributes to be automatically adjusted based on the `node['nodejs']['version']` attribute.

e.g. `default['nodejs']['version'] = '8.x'` should let the Repo URL's update, rather than have to update all the individual attributes.

Rather than create a separate attribute for `repo_version`, use the `node['nodejs']['version']` attribute to reduce ambiguity.

This does not affect users who are explicitly setting these attributes in wrapper cookbooks.