### PR TITLE
Change default version to 10.15.3

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -24,17 +24,16 @@ else
   default['nodejs']['install_method'] = 'source'
 end
 
-default['nodejs']['version'] = '8.12.0'
+default['nodejs']['version'] = '10.15.3'
 
 default['nodejs']['prefix_url']['node'] = 'https://nodejs.org/dist/'
 
 default['nodejs']['source']['url']      = nil # Auto generated
-default['nodejs']['source']['checksum'] = 'b4797843136edd9195c28221a1680ae52c29d867fc5fc1c99f7d6e2f2126a67b'
+default['nodejs']['source']['checksum'] = 'db460a63d057ac015b75bb6a879fcbe2fefaaf22afa4b6f6445b9db61ce2270d'
 
 default['nodejs']['binary']['url'] = nil # Auto generated
-default['nodejs']['binary']['checksum']['linux_x64'] = '3df19b748ee2b6dfe3a03448ebc6186a3a86aeab557018d77a0f7f3314594ef6'
-default['nodejs']['binary']['checksum']['linux_x86'] = '56ecffbd8a656991f71e4b53ab00af333c97453062cadc20a2103b933088d24d'
-default['nodejs']['binary']['checksum']['linux_arm64'] = '781ecf1ecb14b4c671ef0732988636282d6fb7071c4bd52567f663b008796bc9'
+default['nodejs']['binary']['checksum']['linux_x64'] = '6c35b85a7cd4188ab7578354277b2b2ca43eacc864a2a16b3669753ec2369d52'
+default['nodejs']['binary']['checksum']['linux_arm64'] = 'c82cd99e01f6e26830f0b3e0465f12f92957ebd69a68c91c03228c2669104359'
 
 default['nodejs']['make_threads'] = node['cpu'] ? node['cpu']['total'].to_i : 2
 

--- a/attributes/repo.rb
+++ b/attributes/repo.rb
@@ -1,12 +1,12 @@
 case node['platform_family']
 when 'debian'
   default['nodejs']['install_repo'] = true
-  default['nodejs']['repo']         = 'https://deb.nodesource.com/node_6.x'
+  default['nodejs']['repo']         = 'https://deb.nodesource.com/node_10.x'
   default['nodejs']['keyserver']    = 'keyserver.ubuntu.com'
   default['nodejs']['key']          = '1655a0ab68576280'
 when 'rhel', 'amazon'
   default['nodejs']['install_repo'] = true
   release_ver = platform?('amazon') ? 6 : node['platform_version'].to_i
-  default['nodejs']['repo']         = "https://rpm.nodesource.com/pub_6.x/el/#{release_ver}/$basearch"
+  default['nodejs']['repo']         = "https://rpm.nodesource.com/pub_10.x/el/#{release_ver}/$basearch"
   default['nodejs']['key']          = 'https://rpm.nodesource.com/pub/el/NODESOURCE-GPG-SIGNING-KEY-EL'
 end


### PR DESCRIPTION
### Description

This PR changes the default source & binary version to 10.15.3 which is the LTS release since Oct 2018. Since the 10.x release does not have a x86 build i removed the checksum for this arch.
The repo URLs for package installs have also been updated to the 10.x release.

### Issues Resolved

[List any existing issues this PR resolves]

### Check List

- [ ] All tests pass.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
